### PR TITLE
Random response rewrite

### DIFF
--- a/src/commands/Admin/Missy's Commands/say.ts
+++ b/src/commands/Admin/Missy's Commands/say.ts
@@ -1,6 +1,5 @@
 import { MessageOptions, MessageEditOptions } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
-import MissyClient from '../../../lib/MissyClient';
 import MissyCommand from '../../../lib/structures/base/MissyCommand';
 import { Sendable } from '../../../lib/util/types';
 
@@ -18,7 +17,7 @@ export default class extends MissyCommand {
 	}
 
 	async run(msg: KlasaMessage, [channel = msg, rawText]: [Sendable, string]) {
-		const text = this.client.speakerIDs.has(msg.author!.id) && msg.flags.shh
+		const text = this.client.owners.has(msg.author!) && msg.flags.shh
 			? rawText
 			: `_${msg.author} told me to say:_ ${rawText}`;
 		return this.sendOrEdit(channel, text, msg);
@@ -26,7 +25,7 @@ export default class extends MissyCommand {
 
 	async sendOrEdit(channel: Sendable, text: string, cmdMsg: KlasaMessage) {
 		const options: MessageOptions & MessageEditOptions = {
-			disableEveryone: !this.client.speakerIDs.has(cmdMsg.author!.id),
+			disableEveryone: !this.client.owners.has(cmdMsg.author!),
 		};
 
 		const prevMsg: KlasaMessage | undefined = (<any>cmdMsg)[this.msgSymbol];

--- a/src/commands/Fun/Image/no-u.ts
+++ b/src/commands/Fun/Image/no-u.ts
@@ -23,6 +23,10 @@ export default class extends MissyCommand {
 	}
 
 	async run(msg: KlasaMessage, [, infinity]: [string, string?]) {
+		return this.noU(msg, !!infinity);
+	}
+
+	noU(msg: KlasaMessage, infinity = false) {
 		return msg.sendLoading(
 			() => this.client.assets.get(`no-u${infinity ? '-infinity' : ''}`).uploadTo(msg),
 			{ loadingText: msg.language.get('COMMAND_NOU_LOADING_TEXT') }

--- a/src/commands/Scolding/eat.ts
+++ b/src/commands/Scolding/eat.ts
@@ -1,6 +1,5 @@
 import { User } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
-import MissyClient from '../../lib/MissyClient';
 import MissyCommand from '../../lib/structures/base/MissyCommand';
 
 export default class extends MissyCommand {
@@ -14,11 +13,11 @@ export default class extends MissyCommand {
 	}
 
 	async run(msg: KlasaMessage, [meal, who = this.client.user!]: [string | undefined, User?]) {
-		return msg.sendRandom(
-			who.id === this.client.user!.id || !meal ? 'COMMAND_EAT_SELF' : 'COMMAND_EAT',
-			[meal, who, msg.author],
-			[msg]
-		);
+		if (!meal) {
+			who = this.client.user!;
+			meal = 'something';
+		}
+		return msg.sendLocale('COMMAND_EAT', [who, meal, msg]);
 	}
 
 }

--- a/src/commands/Scolding/sleep.ts
+++ b/src/commands/Scolding/sleep.ts
@@ -16,17 +16,13 @@ export default class extends MissyCommand {
 	}
 
 	async run(msg: KlasaMessage, [who = this.client.user!]: [User?]): Promise<KlasaMessage | KlasaMessage[] | never> {
-		if (who.id === this.client.user!.id) {
-			if (this.client.options.owners.includes(msg.author!.id)) {
-				await msg.channel.send('Aw, boo. Yes sir');
-				await naturalPause();
-				return (<RebootCmd><MissyCommand>this.store.get('reboot')).run(msg);
-			}
-
-			return msg.sendRandom('COMMAND_SLEEP_SELF', [who, msg.author], [msg]);
+		if (who.id === this.client.user!.id && await msg.hasAtLeastPermissionLevel(10)) {
+			await msg.channel.send('Aw, boo. Yes sir');
+			await naturalPause();
+			return (<RebootCmd><MissyCommand>this.store.get('reboot')).run(msg);
 		}
 
-		return msg.sendRandom('COMMAND_SLEEP', [who, msg.author]);
+		return msg.sendLocale('COMMAND_SLEEP', [who, msg]);
 	}
 
 }

--- a/src/commands/User Interaction/fakeban.ts
+++ b/src/commands/User Interaction/fakeban.ts
@@ -1,5 +1,4 @@
 import { CommandStore, KlasaMessage } from 'klasa';
-import MissyClient from '../../lib/MissyClient';
 import MissyCommand from '../../lib/structures/base/MissyCommand';
 
 export default class extends MissyCommand {
@@ -13,7 +12,7 @@ export default class extends MissyCommand {
 	}
 
 	run(msg: KlasaMessage) {
-		return msg.sendRandom('COMMAND_FAKEBAN');
+		return msg.sendLocale('COMMAND_FAKEBAN');
 	}
 
 }

--- a/src/commands/User Interaction/fakekick.ts
+++ b/src/commands/User Interaction/fakekick.ts
@@ -1,5 +1,4 @@
 import { CommandStore, KlasaMessage } from 'klasa';
-import MissyClient from '../../lib/MissyClient';
 import MissyCommand from '../../lib/structures/base/MissyCommand';
 
 export default class extends MissyCommand {
@@ -13,7 +12,7 @@ export default class extends MissyCommand {
 	}
 
 	run(msg: KlasaMessage) {
-		return msg.sendRandom('COMMAND_FAKEKICK');
+		return msg.sendLocale('COMMAND_FAKEKICK');
 	}
 
 }

--- a/src/events/commandUnknown.ts
+++ b/src/events/commandUnknown.ts
@@ -56,7 +56,7 @@ export default class UnknownCmd extends MissyEvent {
 		if (text === 'not you') return this.notYou.ignoreChannel(msg);
 
 		if (prefix === this.client.mentionPrefix) {
-			return msg.sendRandom('EVENT_COMMAND_UNKNOWN_UNKNOWN');
+			return msg.sendLocale('EVENT_COMMAND_UNKNOWN_UNKNOWN');
 		}
 	}
 

--- a/src/events/commandlessMessage.ts
+++ b/src/events/commandlessMessage.ts
@@ -3,6 +3,7 @@ import { KlasaMessage } from 'klasa';
 import MissyEvent from '../lib/structures/base/MissyEvent';
 import CmdHandler from '../monitors/commandHandler';
 import IgnoreNotYou from '../inhibitors/ignoreNotYou';
+import { USER_IDS } from '../lib/util/constants';
 
 const cmdWatchingSymbol = Symbol();
 
@@ -13,10 +14,8 @@ type ChannelWithCmdWatchingMap = (TextChannel | DMChannel) & {
 export default class CmdlessMsgEvent extends MissyEvent {
 
 	memePingers: Snowflake[] = [
-		// Hutch
-		'224236171838881792',
-		// Kru
-		'168161111210852352',
+		USER_IDS.HUTCH,
+		'168161111210852352', // Kru
 	];
 
 	get cmdHandler(): CmdHandler {

--- a/src/events/commandlessMessage.ts
+++ b/src/events/commandlessMessage.ts
@@ -44,9 +44,9 @@ export default class CmdlessMsgEvent extends MissyEvent {
 		}
 
 		if (msg.mentions.has(this.client.user!)) {
-			return msg.send(this.memePingers.includes(msg.author!.id) ?
-				msg.language.get('EVENT_COMMANDLESS_MESSAGE_MENTION_MEMERS') :
-				msg.language.getRandom('EVENT_COMMANDLESS_MESSAGE_MENTION'));
+			return msg.sendLocale(this.memePingers.includes(msg.author!.id) ?
+				'EVENT_COMMANDLESS_MESSAGE_MENTION_MEMERS' :
+				'EVENT_COMMANDLESS_MESSAGE_MENTION');
 		}
 
 		return undefined;

--- a/src/extendables/channelExtension.ts
+++ b/src/extendables/channelExtension.ts
@@ -39,19 +39,6 @@ export default class extends Extendable {
 
 	// Sending responses
 
-	sendRandom(
-		this: ExtChannel,
-		key: string, localeArgs: any[] = [], localeResponseArgs: any[] = [], options: MessageOptions = {},
-	): Promise<KlasaMessage | KlasaMessage[]> {
-		if (!Array.isArray(localeResponseArgs)) {
-			if (!Array.isArray(localeArgs)) [options, localeArgs] = [localeArgs, []];
-			else [options, localeResponseArgs] = [localeResponseArgs, []];
-		}
-		const response = resolveLang(this).getRandom(key, localeArgs, localeResponseArgs);
-		assert(typeof response === 'string');
-		return this.sendMessage(response, options);
-	}
-
 	/**
 	 * @param cb The callback function to call in the middle
 	 * @param options Extra options

--- a/src/extendables/messageExtension.ts
+++ b/src/extendables/messageExtension.ts
@@ -37,25 +37,6 @@ export default class extends Extendable {
 	// Sending responses
 
 	/**
-	 * Sends a message that will be editable via command editing (if nothing is attached)
-	 * @param key The Language key to send
-	 * @param localeArgs The language arguments to pass
-	 * @param localeResponseArgs The language response arguments to pass
-	 * @param options The D.JS message options plus Language arguments
-	 */
-	sendRandom(
-		this: Message,
-		key: string, localeArgs: any[] = [], localeResponseArgs: any[] = [], options: MessageOptions = {},
-	): Promise<Message | Message[]> {
-		if (!Array.isArray(localeResponseArgs)) {
-			if (!Array.isArray(localeArgs)) [options, localeArgs] = [localeArgs, []];
-			else [options, localeResponseArgs] = [localeResponseArgs, []];
-		}
-		const response = this.language.getRandom(key, localeArgs, localeResponseArgs);
-		return this.sendMessage(response, options);
-	}
-
-	/**
 	 * @param cb The callback function to call in the middle
 	 * @param options Extra options
 	 * @param options.loadingText Text to send before the callback

--- a/src/finalizers/notYou.ts
+++ b/src/finalizers/notYou.ts
@@ -30,7 +30,7 @@ export default class extends MissyFinalizer {
 
 	ignoreChannel(msg: KlasaMessage) {
 		this.client.ignoredChannels.add(msg.channel.id);
-		return msg.channel.sendRandom('FINALIZER_NOTYOU');
+		return msg.channel.sendLocale('FINALIZER_NOTYOU');
 	}
 
 }

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -66,19 +66,23 @@ export default class extends MissyLanguage {
 
 		// Custom events
 		EVENT_COMMANDLESS_MESSAGE_LISTEN: 'Yes? 👂',
-		EVENT_COMMANDLESS_MESSAGE_MENTION: [
-			'Did someone mention me?',
-			'You called?',
-			'Yay! Mentions!',
-		],
+		EVENT_COMMANDLESS_MESSAGE_MENTION: this.rr({
+			everyone: [
+				'Did someone mention me?',
+				'You called?',
+				'Yay! Mentions!',
+			],
+		}),
 		EVENT_COMMANDLESS_MESSAGE_MENTION_MEMERS: 'Was it Hutch or Kru this time? XD',
-		EVENT_COMMAND_UNKNOWN_UNKNOWN: [
-			"I don't know what that means, sorry @_@",
-			"I'm so confused @_@",
-			"I'm too dumb, sorry XD",
-			"I'm a potato!",
-			"I didn't get that @_@",
-		],
+		EVENT_COMMAND_UNKNOWN_UNKNOWN: this.rr({
+			everyone: [
+				"I don't know what that means, sorry @_@",
+				"I'm so confused @_@",
+				"I'm too dumb, sorry XD",
+				"I'm a potato!",
+				"I didn't get that @_@",
+			],
+		}),
 		EVENT_COMMAND_UNKNOWN_MARBLES: "They're nice, and all, but I seem to have lost all of mine @_@",
 
 		// Monitors
@@ -98,12 +102,14 @@ export default class extends MissyLanguage {
 		INHIBITOR_RUNIN_NONE: (name) => `The ${name} command is not configured to run in any channel.`,
 
 		// Custom finalizers
-		FINALIZER_NOTYOU: [
-			'Oh, sorry! Ping me when you want me.',
-			"Alright, I'll go play somewhere else until @'d",
-			'Understood 👍 To get my attention, @mention me',
-		],
-		FINALIZER_DELETE_FLAG_NO_DELETE: '❌ | I couldn\'t delete your message, sorry :/',
+		FINALIZER_NOTYOU: this.rr({
+			everyone: [
+				'Oh, sorry! Ping me when you want me.',
+				"Alright, I'll go play somewhere else until @'d",
+				'Understood 👍 To get my attention, @mention me',
+			],
+		}),
+		FINALIZER_DELETE_FLAG_NO_DELETE: "❌ | I couldn't delete your message, sorry :/",
 
 		// Core commands
 		COMMAND_BLACKLIST_DESCRIPTION: 'Blacklists or un-blacklists users and servers from the bot.',

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -23,16 +23,6 @@ export default class extends MissyLanguage {
 			}${smartJoin(prefixes.map(pre => `\`${pre}\``))}.`;
 		},
 
-		PLAYING_ACTIVITY: [
-			['with myself 🎮'],
-			['with potatoes! 🥔'],
-			['with myself (why is this so funny? 🤔)'],
-			['for your command 💂', { type: 'WATCHING' }],
-			["with myself (seriously, guys, what's so funny? @_@)"],
-			['EDM 💃🏽', { type: 'LISTENING' }],
-			['rock music 🤘', { type: 'LISTENING' }],
-		],
-
 		// Resolver and prompts
 
 		RESOLVER_MULTI_TOO_FEW: (name, min = 1) => `Provided too few ${name}s. Atleast ${min} ${min === 1 ? 'is' : 'are'} required.`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -1,18 +1,10 @@
-import { util, constants, KlasaMessage } from 'klasa';
-import MissyLanguage from '../lib/structures/base/MissyLanguage';
+import { util, constants as klasaConstants, KlasaMessage } from 'klasa';
+import MissyLanguage, { Value } from '../lib/structures/base/MissyLanguage';
 import { smartJoin } from '../lib/util/util';
 import { IndexedObj } from '../lib/util/types';
-import RandomResponse, { rr } from '../lib/util/RandomResponse';
-import { KlasaUser } from 'klasa';
+import CommandNoU from '../commands/Fun/Image/no-u';
 
-type PlayingActivity = [string, { type: string }?];
-
-type ValueFn = (...args: any[]) => string | string[];
-
-type Value =
-	| string | string[] | ValueFn
-	| PlayingActivity[]
-	| RandomResponse;
+const { TIME } = klasaConstants;
 
 export default class extends MissyLanguage {
 
@@ -166,7 +158,7 @@ export default class extends MissyLanguage {
 		COMMAND_LOAD_DESCRIPTION: 'Load a piece from your bot.',
 		COMMAND_PING: (ping, embed) => embed
 			.addField(`${this.DISCORD_EMOJI} Ping:`, 'Pinging Discord...')
-			.addField('💓 Heartbeat:', `${Math.round(constants.TIME.MINUTE / ping)} bpm (1 every ${Math.round(ping)} ms)`)
+			.addField('💓 Heartbeat:', `${Math.round(TIME.MINUTE / ping)} bpm (1 every ${Math.round(ping)} ms)`)
 			.setFooter("Bots have faster heartbeats than humans, so don't worry if mine is really high!"),
 		COMMAND_PING_DESCRIPTION: 'Check my connection to Discord.',
 		COMMAND_PINGPONG: (diff, embed) => {
@@ -254,44 +246,58 @@ export default class extends MissyLanguage {
 		].join('\n'),
 		COMMAND_PREFIX_DESCRIPTION: 'See the prefixes you can use on this server.',
 		COMMAND_SLEEP_DESCRIPTION: 'Tell someone to get their butt to bed!',
-		COMMAND_SLEEP: (user, author) => [
-			`Go to sleep, ${user}!`,
-			`${user}, make sure you're getting enough sleep, little one!`,
-			`${user}, ${author} says it's bedtime.`,
-			`${user}, get your butt to sleep, little one.`,
-			`Please sleep buttercup ${user}`,
-		],
-		COMMAND_SLEEP_SELF: [
-			"But I'm a robot, I don't need to sleep ;-;",
-			"You can't tell me to sleep!",
-			['Nooooooo', "It's not bedtime yet!"],
-			(msg: KlasaMessage) => this.client.commands.get('no-u').run(msg, []),
-		],
+		COMMAND_SLEEP: this.rr({
+			everyone: [
+				user => `Go to sleep, ${user}!`,
+				user => `${user}, make sure you're getting enough sleep, little one!`,
+				(user, { author }: KlasaMessage) => `${user}, ${author} says it's bedtime.`,
+				user => `${user}, get your butt to sleep, little one.`,
+				user => `Please sleep buttercup ${user}`,
+			],
+			self: [
+				"But I'm a robot, I don't need to sleep ;-;",
+				"You can't tell me to sleep!",
+				['Nooooooo', "It's not bedtime yet!"],
+				(_user, msg: KlasaMessage) => {
+					(this.client.commands.get('no-u') as CommandNoU).noU(msg);
+					return 'no u';
+				},
+			],
+		}),
 		COMMAND_LEWD_DESCRIPTION: 'Nice try. 😝',
 		COMMAND_LEWD_LOADING_TEXT: '<.<\n>.>',
 		COMMAND_LEWD_NSFW_HINT: '(Psst, try this command in a NSFW channel for a surprise! 🤐)',
 		COMMAND_EAT_DESCRIPTION: 'Tell someone to eat.',
-		COMMAND_EAT: (something, user, author) => [
-			`Eat ${something}, ${user}!`,
-			`${user}, make sure you're eating enough, little one!`,
-			`${user}, ${author} says to eat ${something}.`,
-			`${user}, eat ${something}, little one.`,
-		],
-		COMMAND_EAT_SELF: [
-			"But I'm a robot, I don't need to eat ;-;",
-			(msg: KlasaMessage) => msg.send(`But I'm already eating. I have ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB of heap memory in my belly.`),
-			(msg: KlasaMessage) => this.client.commands.get('no-u').run(msg, []),
-		],
-		COMMAND_FAKEBAN: [
-			'Please give them another chance ;-;',
-			"Won't you give them another chance? For me?",
-			'Awww, are you going to ban them?',
-		],
-		COMMAND_FAKEKICK: [
-			'Aw, do we have to?',
-			'Have you tried asking them nicely?',
-			"I bet they'll behave from now on. Right?",
-		],
+		COMMAND_EAT: this.rr({
+			everyone: [
+				(user, something: string) => `Eat ${something}, ${user}!`,
+				user => `${user}, make sure you're eating enough, little one!`,
+				(user, something: string, { author }: KlasaMessage) => `${user}, ${author} says to eat ${something}.`,
+				(user, something: string) => `${user}, eat ${something}, little one.`,
+			],
+			self: [
+				"But I'm a robot, I don't need to eat ;-;",
+				() => `But I'm already eating. I have ${(process.memoryUsage().heapUsed / 1024 / 1024).toFixed(2)} MB of heap memory in my belly.`,
+				(_user, _something, msg: KlasaMessage) => {
+					(this.client.commands.get('no-u') as CommandNoU).noU(msg);
+					return 'no u';
+				},
+			],
+		}),
+		COMMAND_FAKEBAN: this.rr({
+			everyone: [
+				'Please give them another chance ;-;',
+				"Won't you give them another chance? For me?",
+				'Awww, are you going to ban them?',
+			],
+		}),
+		COMMAND_FAKEKICK: this.rr({
+			everyone: [
+				'Aw, do we have to?',
+				'Have you tried asking them nicely?',
+				"I bet they'll behave from now on. Right?",
+			],
+		}),
 		COMMAND_BIRTHDAY_DESCRIPTION: 'Wish someone (or multiple people) a happy birthday 🎂',
 		COMMAND_BIRTHDAY: 'Happy birthday!',
 		COMMAND_BIRTHDAY_MENTIONS: users => `Happy birthday, ${smartJoin(users)}!`,
@@ -340,11 +346,11 @@ export default class extends MissyLanguage {
 		COMMAND_NOCONTEXT_DESCRIPTION: 'Get a no-context quote from Missy.',
 		COMMAND_INTERACTION_EXTENDEDHELP: "If you don't mention anyone, I'll assume you mean the person above you.",
 		COMMAND_ATTACK_DESCRIPTION: "I'll go on the attack!",
-		COMMAND_ATTACK: rr({
+		COMMAND_ATTACK: this.rr({
 			everyone: [ user => `${user} <a:attack:530938382763819030>` ],
 		}),
 		COMMAND_SLAP_DESCRIPTION: 'If you really want me to, I can slap someone. ✋🏽',
-		COMMAND_SLAP: rr({
+		COMMAND_SLAP: this.rr({
 			everyone: [
 				user => `If I must...\n\n_\\*Slaps ${user} on the cheek!\\* ...except it's more of a firm pat._`,
 			],
@@ -353,11 +359,11 @@ export default class extends MissyLanguage {
 			],
 		}),
 		COMMAND_PUNCH_DESCRIPTION: 'Falcon, PAWWWWNCH! 👊🏽',
-		COMMAND_PUNCH: rr({
+		COMMAND_PUNCH: this.rr({
 			everyone: [user => `_\\*Lightly punches ${user}'s arm\\*_`],
 		}),
 		COMMAND_SPANK_DESCRIPTION: 'Has someone been naughty? Pleasedontmakemedothis',
-		COMMAND_SPANK: rr({
+		COMMAND_SPANK: this.rr({
 			everyone: [
 				user => `_\\*Does not spank ${user}\\*_`,
 				user => `_\\*Swats in the direction of ${user}'s butt, but doesn't make contact\\*_`,

--- a/src/languages/en-US.ts
+++ b/src/languages/en-US.ts
@@ -2,12 +2,23 @@ import { util, constants, KlasaMessage } from 'klasa';
 import MissyLanguage from '../lib/structures/base/MissyLanguage';
 import { smartJoin } from '../lib/util/util';
 import { IndexedObj } from '../lib/util/types';
+import RandomResponse, { rr } from '../lib/util/RandomResponse';
+import { KlasaUser } from 'klasa';
+
+type PlayingActivity = [string, { type: string }?];
+
+type ValueFn = (...args: any[]) => string | string[];
+
+type Value =
+	| string | string[] | ValueFn
+	| PlayingActivity[]
+	| RandomResponse;
 
 export default class extends MissyLanguage {
 
 	DISCORD_EMOJI = '<:discord:503738729463021568>';
 
-	language: IndexedObj<string | string[] | any[] | ((...args: any[]) => string | string[])> = {
+	language: IndexedObj<Value> = {
 		PREFIX_REMINDER: ({ prefix, disableNaturalPrefix }) => {
 			const prefixes = [];
 			if (!disableNaturalPrefix) prefixes.push(this.client.PREFIX_PLAIN);
@@ -329,38 +340,36 @@ export default class extends MissyLanguage {
 		COMMAND_NOCONTEXT_DESCRIPTION: 'Get a no-context quote from Missy.',
 		COMMAND_INTERACTION_EXTENDEDHELP: "If you don't mention anyone, I'll assume you mean the person above you.",
 		COMMAND_ATTACK_DESCRIPTION: "I'll go on the attack!",
-		COMMAND_ATTACK: user => [`${user} <a:attack:530938382763819030>`],
+		COMMAND_ATTACK: rr({
+			everyone: [ user => `${user} <a:attack:530938382763819030>` ],
+		}),
 		COMMAND_SLAP_DESCRIPTION: 'If you really want me to, I can slap someone. ✋🏽',
-		COMMAND_SLAP: user => {
-			const a = [
-				`If I must...\n\n_\\*Slaps ${user} on the cheek!\\* ...except it's more of a firm pat._`,
-			];
-			return [
-				...a,
-				...a,
-				...a,
-				`_\\*Slaps ${user} hard across the face\\*_ ...Oh! I'm sorry! I hit too hard ;-;`,
-			];
-		},
+		COMMAND_SLAP: rr({
+			everyone: [
+				user => `If I must...\n\n_\\*Slaps ${user} on the cheek!\\* ...except it's more of a firm pat._`,
+			],
+			everyoneRare: [
+				user => `_\\*Slaps ${user} hard across the face\\*_ ...Oh! I'm sorry! I hit too hard ;-;`,
+			],
+		}),
 		COMMAND_PUNCH_DESCRIPTION: 'Falcon, PAWWWWNCH! 👊🏽',
-		COMMAND_PUNCH: user => [`_\\*Lightly punches ${user}'s arm\\*_`],
+		COMMAND_PUNCH: rr({
+			everyone: [user => `_\\*Lightly punches ${user}'s arm\\*_`],
+		}),
 		COMMAND_SPANK_DESCRIPTION: 'Has someone been naughty? Pleasedontmakemedothis',
-		COMMAND_SPANK: user => {
-			const a = [
-				`Does not spank ${user}`,
-				`Swats in the direction of ${user}'s butt, but doesn't make contact`,
-				`Pats ${user}'s back`,
-				`Lightly smacks the side of ${user}'s butt with her fingertips`,
-				`Lets ${user} off with a warning`,
-			].map(s => `_\\*${s}\\*_`);
-			return [
-				...a,
-				...a,
-				...a,
+		COMMAND_SPANK: rr({
+			everyone: [
+				user => `_\\*Does not spank ${user}\\*_`,
+				user => `_\\*Swats in the direction of ${user}'s butt, but doesn't make contact\\*_`,
+				user => `_\\*Pats ${user}'s back\\*_`,
+				user => `_\\*Lightly smacks the side of ${user}'s butt with her fingertips\\*_`,
+				user => `_\\*Lets ${user} off with a warning\\*_`,
+			],
+			everyoneRare: [
 				// eslint-disable-next-line max-len
-				`_\\*Forces ${user} over her lap\\*_ Take that! _\\*Spanks\\*_ And that! _\\*Spanks\\*_...\n\nNow be good, or I'll pull your pants down next time! ...What? Why are you looking at me like that?`,
-			];
-		},
+				user => `_\\*Forces ${user} over her lap\\*_ Take that! _\\*Spanks\\*_ And that! _\\*Spanks\\*_...\n\nNow be good, or I'll pull your pants down next time! ...What? Why are you looking at me like that?`,
+			],
+		}),
 		COMMAND_QUOTE_DESCRIPTION: 'Quote a message. (Turn on developer mode in Discord in order to copy IDs and links.)',
 		COMMAND_QUOTE_EXTENDEDHELP: '',
 

--- a/src/lib/MissyClient.ts
+++ b/src/lib/MissyClient.ts
@@ -5,10 +5,11 @@ import path from 'path';
 import git from 'simple-git/promise';
 import { Permissions, Snowflake, TextChannel, User } from 'discord.js';
 import {
-	KlasaClient, Schema, PermissionLevels,
+	KlasaClient, Schema, PermissionLevels, Store,
 	KlasaClientOptions, ConsoleOptions,
 } from 'klasa';
 import MissyCommand from './structures/base/MissyCommand';
+import MissyLanguage from './structures/base/MissyLanguage';
 import { MissyStdoutStream, MissyStderrStream, MissyStream } from './MissyStreams';
 import AssetStore from './structures/AssetStore';
 // import ObjectStore from './structures/ObjectStore';
@@ -31,10 +32,20 @@ const COLORS = {
 	BLUE: 0x0074D9,
 };
 
+export class MissyLanguageStore extends Store<string, MissyLanguage, typeof MissyLanguage> {
+	public readonly default: MissyLanguage;
+	constructor(client: KlasaClient) {
+		super(client, 'languages', MissyLanguage);
+		throw new Error("This is just for types; don't instantiate it.");
+	}
+}
+
 export default class MissyClient extends KlasaClient {
 
 	// @ts-ignore assigned in the parent class
 	options: Required<MissyClientOptions>;
+	// @ts-ignore this too
+	languages: MissyLanguageStore;
 
 	COLORS: typeof COLORS;
 

--- a/src/lib/MissyClient.ts
+++ b/src/lib/MissyClient.ts
@@ -14,6 +14,7 @@ import AssetStore from './structures/AssetStore';
 // import ObjectStore from './structures/ObjectStore';
 import profanity from './profanity';
 import { mergeDefault } from './util/util';
+import { USER_IDS } from './util/constants';
 
 export interface MissyClientOptions extends KlasaClientOptions {
 	console?: ConsoleOptions & {
@@ -23,11 +24,6 @@ export interface MissyClientOptions extends KlasaClientOptions {
 	missyLogChannel?: Snowflake;
 	missyErrorChannel?: Snowflake;
 }
-
-const USER_IDS = {
-	HUTCH: '224236171838881792',
-	MISSY: '398127472564240387',
-};
 
 const COLORS = {
 	WHITE: 0xFFFFFF,

--- a/src/lib/MissyClient.ts
+++ b/src/lib/MissyClient.ts
@@ -32,20 +32,10 @@ const COLORS = {
 	BLUE: 0x0074D9,
 };
 
-export class MissyLanguageStore extends Store<string, MissyLanguage, typeof MissyLanguage> {
-	public readonly default: MissyLanguage;
-	constructor(client: KlasaClient) {
-		super(client, 'languages', MissyLanguage);
-		throw new Error("This is just for types; don't instantiate it.");
-	}
-}
-
 export default class MissyClient extends KlasaClient {
 
 	// @ts-ignore assigned in the parent class
 	options: Required<MissyClientOptions>;
-	// @ts-ignore this too
-	languages: MissyLanguageStore;
 
 	COLORS: typeof COLORS;
 

--- a/src/lib/structures/Asset.ts
+++ b/src/lib/structures/Asset.ts
@@ -3,7 +3,6 @@ import { join } from 'path';
 import { readFile } from 'fs-nextra';
 import { MessageOptions, FileOptions } from 'discord.js';
 import { Piece, PieceOptions, KlasaMessage } from 'klasa';
-import MissyClient from '../MissyClient';
 import AssetStore from './AssetStore';
 import { capitalizeFirstLetter } from '../util/util';
 import { Sendable } from '../util/types';
@@ -24,9 +23,6 @@ export interface AssetOptions extends PieceOptions {
  * @extends {Piece}
  */
 class Asset extends Piece {
-
-	// @ts-ignore assigned in the parent class
-	readonly client: MissyClient;
 
 	title: string;
 

--- a/src/lib/structures/InteractionCommand.ts
+++ b/src/lib/structures/InteractionCommand.ts
@@ -15,7 +15,7 @@ export default class InteractionCommand extends MissyCommand {
 	}
 
 	run(msg: KlasaMessage, [user = getAboveUser(msg)]) {
-		return msg.sendRandom(`COMMAND_${this.name.toUpperCase()}`, [user]);
+		return msg.sendLocale(`COMMAND_${this.name.toUpperCase()}`, [user]);
 	}
 
 }

--- a/src/lib/structures/InteractionCommand.ts
+++ b/src/lib/structures/InteractionCommand.ts
@@ -1,6 +1,5 @@
 import { CommandStore, KlasaMessage } from 'klasa';
 import { mergeDefault, getAboveUser } from '../util/util';
-import MissyClient from '../MissyClient';
 import MissyCommand, { MissyCommandOptions } from './base/MissyCommand';
 
 export default class InteractionCommand extends MissyCommand {

--- a/src/lib/structures/base/MissyLanguage.ts
+++ b/src/lib/structures/base/MissyLanguage.ts
@@ -3,10 +3,9 @@ import MissyClient from '../../MissyClient';
 import RandomResponse, { RandomResponseArgs } from '../../util/RandomResponse';
 import { IndexedObj } from '../../util/types';
 
-export type ValueFn = (...args: any[]) => string | string[];
-
 export type Value =
-	| string | string[] | ValueFn
+	| string | string[]
+	| ((...args: any[]) => string | string[])
 	| RandomResponse;
 
 export default abstract class MissyLanguage extends Language {

--- a/src/lib/structures/base/MissyLanguage.ts
+++ b/src/lib/structures/base/MissyLanguage.ts
@@ -1,11 +1,17 @@
-import {
-	Language,
-} from 'klasa';
+import { Language } from 'klasa';
 import MissyClient from '../../MissyClient';
+import RandomResponse from '../../util/RandomResponse';
 
 export default abstract class MissyLanguage extends Language {
 
 	// @ts-ignore assigned in the parent class
 	readonly client: MissyClient;
+
+	get<T = string>(term: string, ...args: any[]): T {
+		const value: T | RandomResponse = super.get(term, ...args);
+		return typeof value === 'object' && value instanceof RandomResponse ?
+			value.run(this.client, args[0], ...args) as any as T :
+			value;
+	}
 
 }

--- a/src/lib/structures/base/MissyLanguage.ts
+++ b/src/lib/structures/base/MissyLanguage.ts
@@ -3,13 +3,10 @@ import MissyClient from '../../MissyClient';
 import RandomResponse, { RandomResponseArgs } from '../../util/RandomResponse';
 import { IndexedObj } from '../../util/types';
 
-export type PlayingActivity = [string] | [string, { type: string }];
-
 export type ValueFn = (...args: any[]) => string | string[];
 
 export type Value =
 	| string | string[] | ValueFn
-	| PlayingActivity[]
 	| RandomResponse;
 
 export default abstract class MissyLanguage extends Language {

--- a/src/lib/structures/base/MissyLanguage.ts
+++ b/src/lib/structures/base/MissyLanguage.ts
@@ -1,11 +1,26 @@
 import { Language } from 'klasa';
 import MissyClient from '../../MissyClient';
-import RandomResponse from '../../util/RandomResponse';
+import RandomResponse, { RandomResponseArgs } from '../../util/RandomResponse';
+import { IndexedObj } from '../../util/types';
+
+export type PlayingActivity = [string] | [string, { type: string }];
+
+export type ValueFn = (...args: any[]) => string | string[];
+
+export type Value =
+	| string | string[] | ValueFn
+	| PlayingActivity[]
+	| RandomResponse;
 
 export default abstract class MissyLanguage extends Language {
 
 	// @ts-ignore assigned in the parent class
 	readonly client: MissyClient;
+	// @ts-ignore same
+	language: IndexedObj<Value>;
+
+	/** A shortcut for constructing a RandomResponse instance */
+	protected rr = (args: RandomResponseArgs) => RandomResponse.build(this.client, args);
 
 	get<T = string>(term: string, ...args: any[]): T {
 		const value: T | RandomResponse = super.get(term, ...args);

--- a/src/lib/util/RandomResponse.ts
+++ b/src/lib/util/RandomResponse.ts
@@ -1,8 +1,8 @@
 import { Snowflake, UserResolvable } from 'discord.js';
+import { KlasaUser, KlasaMessage } from 'klasa';
 import MissyClient from '../MissyClient';
 import { arrayRandom, randomBetween } from './util';
 import { USER_IDS } from './constants';
-import { KlasaUser } from 'klasa';
 
 const allDigitsRegex = /^\d+$/;
 /** 1 in 20 chance */
@@ -12,11 +12,15 @@ const userResolvableOrThrow = (value: any): value is UserResolvable => {
 	return true;
 };
 
-type Value = string | ((...args: [KlasaUser, ...any[]]) => string);
+// string[] is allowed since arrays are automatically joined with '\n'
+type Value = string | string[] |
+	// Messages are allowed to be returned as a no-op, if the response is handled in the function
+	((...args: [KlasaUser, ...any[]]) => string | string[] | Promise<KlasaMessage | KlasaMessage[]>);
 
 export type RandomResponseArgs = {
 	everyone: Value[];
 	everyoneRare?: Value[];
+	self?: Value[];
 	[USER_IDS.HUTCH]?: Value[];
 	[USER_IDS.MISSY]?: Value[];
 };
@@ -27,41 +31,54 @@ type LooseRandomResponseArgs = RandomResponseArgs & {
 
 export default class RandomResponse {
 
+	private readonly client: MissyClient;
 	private readonly everyone: readonly Value[];
 	private readonly rare: readonly Value[] | null;
+	private readonly self: readonly Value[] | null;
 	private readonly userSpecific: ReadonlyMap<Snowflake, readonly Value[]> | null;
 
-	constructor(everyone: Value[], everyoneRare: Value[] | null, userSpecific: Map<Snowflake, Value[]> | null) {
+	constructor(client: MissyClient, everyone: Value[], everyoneRare: Value[] | null, self: Value[] | null, userSpecific: Map<Snowflake, Value[]> | null) {
+		this.client = client;
 		this.everyone = everyone;
 		this.rare = everyoneRare;
+		this.self = self;
 		this.userSpecific = userSpecific;
 	}
 
-	static rr(args: RandomResponseArgs) {
+	static build(client: MissyClient, args: RandomResponseArgs) {
 		const userIDs = Object.keys(args).filter(maybeID => allDigitsRegex.test(maybeID));
-		return new RandomResponse(args.everyone, args.everyoneRare || null,
+		return new RandomResponse(
+			client,
+			args.everyone,
+			args.everyoneRare || null,
+			args.self || null,
 			userIDs.length === 0 ?
 				null :
-				new Map(userIDs.map(id => [id, (args as LooseRandomResponseArgs)[id]])));
-	}
-
-	run(client: MissyClient, userResolvable: UserResolvable, ...restArgs: any[]): string {
-		const userID = client.users.resolveID(userResolvable);
-		const value = this.getResponse(userID);
-		return typeof value === 'function' ?
-			value(client.users.get(userID) as KlasaUser, ...restArgs) :
-			value;
-	}
-
-	private getResponse(userID: Snowflake | undefined): Value {
-		const { everyone, rare, userSpecific } = this;
-		return arrayRandom(
-			userSpecific !== null && userResolvableOrThrow(userID) && userSpecific.has(userID) ? userSpecific.get(userID)!
-			: rare !== null && chanceOutOf20() ? rare
-			: everyone
+				new Map(userIDs.map(id => [id, (args as LooseRandomResponseArgs)[id]]))
 		);
 	}
 
-}
+	run(client: MissyClient, userResolvable: UserResolvable, ...restArgs: any[]): string | string[] | undefined {
+		const userID = client.users.resolveID(userResolvable);
+		const value = this.getResponse(userID);
+		if (typeof value !== 'function') return value;
 
-export const { rr } = RandomResponse;
+		const valueReturn = value(client.users.get(userID) as KlasaUser, ...restArgs);
+		return typeof valueReturn === 'string' ?
+			valueReturn :
+			Array.isArray(valueReturn) ? valueReturn : undefined;
+	}
+
+	private getResponse(userID: Snowflake | undefined): Value {
+		let responses: readonly Value[];
+		if (this.self !== null && userResolvableOrThrow(userID) && this.client.user!.id === userID) {
+			responses = this.self;
+		} else if (this.userSpecific !== null && userResolvableOrThrow(userID) && this.userSpecific.has(userID)) {
+			responses = this.userSpecific.get(userID)!;
+		} else {
+			responses = this.rare !== null && chanceOutOf20() ? this.rare : this.everyone;
+		}
+		return arrayRandom(responses);
+	}
+
+}

--- a/src/lib/util/RandomResponse.ts
+++ b/src/lib/util/RandomResponse.ts
@@ -1,0 +1,67 @@
+import { Snowflake, UserResolvable } from 'discord.js';
+import MissyClient from '../MissyClient';
+import { arrayRandom, randomBetween } from './util';
+import { USER_IDS } from './constants';
+import { KlasaUser } from 'klasa';
+
+const allDigitsRegex = /^\d+$/;
+/** 1 in 20 chance */
+const chanceOutOf20 = () => randomBetween(1, 20) === 20;
+const userResolvableOrThrow = (value: any): value is UserResolvable => {
+	if (!value) throw new Error();
+	return true;
+};
+
+type Value = string | ((...args: [KlasaUser, ...any[]]) => string);
+
+export type RandomResponseArgs = {
+	everyone: Value[];
+	everyoneRare?: Value[];
+	[USER_IDS.HUTCH]?: Value[];
+	[USER_IDS.MISSY]?: Value[];
+};
+
+type LooseRandomResponseArgs = RandomResponseArgs & {
+	[k: string]: string[];
+};
+
+export default class RandomResponse {
+
+	private readonly everyone: readonly Value[];
+	private readonly rare: readonly Value[] | null;
+	private readonly userSpecific: ReadonlyMap<Snowflake, readonly Value[]> | null;
+
+	constructor(everyone: Value[], everyoneRare: Value[] | null, userSpecific: Map<Snowflake, Value[]> | null) {
+		this.everyone = everyone;
+		this.rare = everyoneRare;
+		this.userSpecific = userSpecific;
+	}
+
+	static rr(args: RandomResponseArgs) {
+		const userIDs = Object.keys(args).filter(maybeID => allDigitsRegex.test(maybeID));
+		return new RandomResponse(args.everyone, args.everyoneRare || null,
+			userIDs.length === 0 ?
+				null :
+				new Map(userIDs.map(id => [id, (args as LooseRandomResponseArgs)[id]])));
+	}
+
+	run(client: MissyClient, userResolvable: UserResolvable, ...restArgs: any[]): string {
+		const userID = client.users.resolveID(userResolvable);
+		const value = this.getResponse(userID);
+		return typeof value === 'function' ?
+			value(client.users.get(userID) as KlasaUser, ...restArgs) :
+			value;
+	}
+
+	private getResponse(userID: Snowflake | undefined): Value {
+		const { everyone, rare, userSpecific } = this;
+		return arrayRandom(
+			userSpecific !== null && userResolvableOrThrow(userID) && userSpecific.has(userID) ? userSpecific.get(userID)!
+			: rare !== null && chanceOutOf20() ? rare
+			: everyone
+		);
+	}
+
+}
+
+export const { rr } = RandomResponse;

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -1,1 +1,6 @@
 export const SEND_CODE_LIMIT = 2000 - '```\n\n```'.length;
+
+export const USER_IDS = {
+	HUTCH: '224236171838881792',
+	MISSY: '398127472564240387',
+};

--- a/src/lib/util/constants.ts
+++ b/src/lib/util/constants.ts
@@ -3,4 +3,4 @@ export const SEND_CODE_LIMIT = 2000 - '```\n\n```'.length;
 export const USER_IDS = {
 	HUTCH: '224236171838881792',
 	MISSY: '398127472564240387',
-};
+} as const;

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -20,8 +20,6 @@ export type SaneGuild = Guild & {
 };
 
 export interface MissySendAliases {
-	sendRandom(key: string, localeArgs?: any[], localeResponseArgs?: any[], options?: MessageOptions):
-		Promise<KlasaMessage | KlasaMessage[]>;
 	sendLoading<T = KlasaMessage>(cb: (msg: KlasaMessage) => T | Promise<T>, options?: {
 		loadingText?: string,
 	}): Promise<T>;

--- a/src/lib/util/util.ts
+++ b/src/lib/util/util.ts
@@ -55,7 +55,7 @@ export const ensureArray = <T>(arrayOrScalar: T[] | T): T[] =>
 /**
  * @param array An array to retrieve a random element from
  */
-export const arrayRandom = <T>(array: T[]): T =>
+export const arrayRandom = <T>(array: readonly T[]): T =>
 	array[Math.floor(Math.random() * array.length)];
 
 /**

--- a/src/tasks/randomActivity.ts
+++ b/src/tasks/randomActivity.ts
@@ -3,9 +3,21 @@ import {
 	Task, Duration, constants,
 	TaskStore,
 } from 'klasa';
-import { randomBetween } from '../lib/util/util';
+import { randomBetween, arrayRandom } from '../lib/util/util';
 
-export default class extends Task {
+export type PlayingActivity = [string, ActivityOptions?];
+
+export default class RandomActivityTask extends Task {
+
+	static activities: PlayingActivity[] = [
+		['with myself 🎮'],
+		['with potatoes! 🥔'],
+		['with myself (why is this so funny? 🤔)'],
+		['for your command 💂', { type: 'WATCHING' }],
+		["with myself (seriously, guys, what's so funny? @_@)"],
+		['EDM 💃🏽', { type: 'LISTENING' }],
+		['rock music 🤘', { type: 'LISTENING' }],
+	];
 
 	nextTimestamp = Infinity;
 	nextAt: Date | null = null;
@@ -27,7 +39,8 @@ export default class extends Task {
 	}
 
 	setRandomActivity() {
-		return this.client.user!.setActivity(...this.client.languages.default.getRandom<[string, ActivityOptions]>('PLAYING_ACTIVITY'));
+		const act = arrayRandom(RandomActivityTask.activities);
+		return this.client.user!.setActivity(...act);
 	}
 
 	scheduleNext(delay = constants.TIME.MINUTE * randomBetween(15, 120)) {


### PR DESCRIPTION
Something I've been meaning to do for a while: change language keys with multiple values (designed to have one chosen randomly) to be a different type of object rather than just a plain array, which requires remembering to use a `msg.sendRandom` method instead of `msg.sendLocale` (and `lang.getRandom` instead of `lang.get`).

(It's "random-response-rewrite-2" because this is my second attempt at the rewrite. The first one wasn't going very well...)

- Removed the `Language#getRandom` and `Message/TextChannel/DMChannel#sendRandom` methods
- Moved playing activity text from the language file to the random activity task, since playing activities can't be localized
- Moved user ID constants to the constants file and made them a constant type so they can be used constantly in other types (constant constant constant constant constant so much constant...)
- I thought I had already done this, but changed code that depended on `MissyClient#speakerIDs` (which was removed)