### PR TITLE
Fix a ping command edit bug

### DIFF
--- a/src/commands/General/Chat Bot Info/ping.ts
+++ b/src/commands/General/Chat Bot Info/ping.ts
@@ -1,8 +1,7 @@
 import { MessageEmbed } from 'discord.js';
 import { CommandStore, KlasaMessage } from 'klasa';
-import MissyClient from '../../../lib/MissyClient';
 import MissyCommand from '../../../lib/structures/base/MissyCommand';
-import { scalarOrFirst } from '../../../lib/util/util';
+import { sleep } from '../../../lib/util/util';
 
 export default class extends MissyCommand {
 
@@ -14,10 +13,14 @@ export default class extends MissyCommand {
 	}
 
 	async run(msg: KlasaMessage) {
-		const pingMsg = scalarOrFirst(await msg.sendLocale('COMMAND_PING', [
+		const halfSecond = sleep(500);
+		const pingMsg = await msg.sendLocale('COMMAND_PING', [
 			this.client.ws.ping,
 			new MessageEmbed().setColor(this.client.COLORS.BLUE).setThumbnail(this.client.user!.displayAvatarURL()),
-		]));
+		]) as KlasaMessage;
+		// Editing messages too quickly can do weird things, so make sure it's at least been 0.5s
+		await halfSecond;
+
 		return msg.sendLocale('COMMAND_PINGPONG', [
 			(pingMsg.editedTimestamp || pingMsg.createdTimestamp) - (msg.editedTimestamp || msg.createdTimestamp),
 			new MessageEmbed(pingMsg.embeds[0]),


### PR DESCRIPTION
Editing messages too quickly on Discord can cause weird behavior. (Discord's fault tbh.) This gets around that by adding a half second delay.